### PR TITLE
Fix #20 and #24 (use relationship names in include and prevent duplicate resources in included)

### DIFF
--- a/NJsonApiCore.Web.MVCCore.HelloWorld.sln
+++ b/NJsonApiCore.Web.MVCCore.HelloWorld.sln
@@ -16,9 +16,9 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NJsonApiCore", "src\NJsonAp
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NJsonApiCore.Web.MVCCore.HelloWorld", "src\NJsonApiCore.Web.MVCCore.HelloWorld\NJsonApiCore.Web.MVCCore.HelloWorld.xproj", "{3309A597-A8C0-4EB8-9956-7860A5F44F22}"
 EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NJsonApiCore.Test", "test\NJsonApiCore.Test\NJsonApiCore.Test.xproj", "{5A06E121-32A9-4F55-8055-AB27B266EEE1}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{32309EAF-E19A-4274-9D2B-800DF7E84BE5}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NJsonApiCore.Test", "test\NJsonApiCore.Test\NJsonApiCore.Test.xproj", "{5A06E121-32A9-4F55-8055-AB27B266EEE1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/NJsonApiCore/NJsonApiCore.csproj
+++ b/src/NJsonApiCore/NJsonApiCore.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Serialization\Representations\Resources\ResourceCollection.cs" />
     <Compile Include="Serialization\Representations\Resources\SimpleLink.cs" />
     <Compile Include="Serialization\Representations\Resources\SingleResource.cs" />
+    <Compile Include="Serialization\SingleResourceIdentifierComparer.cs" />
     <Compile Include="Serialization\TransformationHelper.cs" />
     <Compile Include="Serialization\UpdateDocument.cs" />
     <Compile Include="Utils\CamelCaseUtil.cs" />

--- a/src/NJsonApiCore/ResourceMapping.cs
+++ b/src/NJsonApiCore/ResourceMapping.cs
@@ -60,7 +60,7 @@ namespace NJsonApi
                 var parts = relationshipPath.Split('.');
                 foreach (var part in parts)
                 {
-                    var relationship = currentMapping.Relationships.SingleOrDefault(x => x.RelatedBaseResourceType == part);
+                    var relationship = currentMapping.Relationships.SingleOrDefault(x => x.RelationshipName == part);
                     if (relationship == null)
                         return false;
 

--- a/src/NJsonApiCore/Serialization/Representations/Relationships/SingleResourceIdentifier.cs
+++ b/src/NJsonApiCore/Serialization/Representations/Relationships/SingleResourceIdentifier.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 using NJsonApi.Serialization.Representations.Resources;
 
 namespace NJsonApi.Serialization.Representations.Relationships

--- a/src/NJsonApiCore/Serialization/SingleResourceIdentifierComparer.cs
+++ b/src/NJsonApiCore/Serialization/SingleResourceIdentifierComparer.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using NJsonApi.Serialization.Representations.Relationships;
+
+namespace NJsonApi.Serialization
+{
+    public sealed class SingleResourceIdentifierComparer : IEqualityComparer<SingleResourceIdentifier>
+    { 
+        public bool Equals(SingleResourceIdentifier x, SingleResourceIdentifier y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (ReferenceEquals(x, null)) return false;
+            if (ReferenceEquals(y, null)) return false;
+            if (x.GetType() != y.GetType()) return false;
+            return string.Equals(x.Id, y.Id) && string.Equals(x.Type, y.Type);
+        }
+
+        public int GetHashCode(SingleResourceIdentifier obj)
+        {
+            unchecked
+            {
+                return ((obj.Id != null ? obj.Id.GetHashCode() : 0) * 397) ^ (obj.Type != null ? obj.Type.GetHashCode() : 0);
+            }
+        }
+    }
+}

--- a/src/NJsonApiCore/Serialization/TransformationHelper.cs
+++ b/src/NJsonApiCore/Serialization/TransformationHelper.cs
@@ -8,6 +8,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using NJsonApi.Utils;
 
 namespace NJsonApi.Serialization
 {
@@ -33,7 +34,19 @@ namespace NJsonApi.Serialization
         public List<SingleResource> CreateIncludedRepresentations(List<object> primaryResourceList, IResourceMapping resourceMapping, Context context)
         {
             var includedList = new List<SingleResource>();
-            var alreadyVisitedObjects = new HashSet<object>(primaryResourceList);
+
+            var primaryResourceIdentifiers = primaryResourceList.Select(x =>
+            {
+                var id = new SingleResourceIdentifier
+                {
+                    Id = resourceMapping.IdGetter(x).ToString(),
+                    Type = resourceMapping.ResourceType
+                };
+
+                return id;
+            });
+
+            var alreadyVisitedObjects = new HashSet<SingleResourceIdentifier>(primaryResourceIdentifiers, new SingleResourceIdentifierComparer());
 
             foreach (var resource in primaryResourceList)
             {
@@ -55,7 +68,7 @@ namespace NJsonApi.Serialization
         private List<SingleResource> AppendIncludedRepresentationRecursive(
             object resource,
             IResourceMapping resourceMapping,
-            HashSet<object> alreadyVisitedObjects,
+            HashSet<SingleResourceIdentifier> alreadyVisitedObjects,
             Context context,
             string parentRelationshipPath = "")
         {
@@ -78,12 +91,18 @@ namespace NJsonApi.Serialization
 
                 foreach (var relatedResource in relatedResources)
                 {
-                    if (alreadyVisitedObjects.Contains(relatedResource))
+                    var relatedResourceId = new SingleResourceIdentifier
+                    {
+                        Id = relationship.ResourceMapping.IdGetter(relatedResource).ToString(),
+                        Type = relationship.ResourceMapping.ResourceType
+                    };
+
+                    if (alreadyVisitedObjects.Contains(relatedResourceId))
                     {
                         continue;
                     }
 
-                    alreadyVisitedObjects.Add(relatedResource);
+                    alreadyVisitedObjects.Add(relatedResourceId);
                     includedResources.Add(
                         CreateResourceRepresentation(relatedResource, relationship.ResourceMapping, context));
 
@@ -99,11 +118,11 @@ namespace NJsonApi.Serialization
         {
             if (string.IsNullOrEmpty(parentRelationshipPath))
             {
-                return relationship.RelatedBaseResourceType;
+                return relationship.RelationshipName;
             }
             else
             {
-                return $"{parentRelationshipPath}.{relationship.RelatedBaseResourceType}";
+                return $"{parentRelationshipPath}.{relationship.RelationshipName}";
             }
         }
 

--- a/test/NJsonApiCore.Test/Builders/PostBuilder.cs
+++ b/test/NJsonApiCore.Test/Builders/PostBuilder.cs
@@ -22,6 +22,18 @@ namespace NJsonApi.Test.Builders
             }
         }
 
+        public static Author Clarke
+        {
+            get
+            {
+                return new Author
+                {
+                    Id = 2,
+                    Name = "Arthur C. Clarke"
+                };
+            }
+        }
+
         public PostBuilder()
         {
             this.post = new Post()
@@ -49,13 +61,14 @@ namespace NJsonApi.Test.Builders
             return this;
         }
 
-        public PostBuilder WithComment(int id, string body)
+        public PostBuilder WithComment(int id, string body, Author author)
         {
             var comment = new Comment()
             {
                 Body= body,
                 Id = id,
-                Post = post
+                Post = post,
+                Author = author
             };
 
             post.Replies.Add(comment);

--- a/test/NJsonApiCore.Test/NJsonApiCore.Test.xproj
+++ b/test/NJsonApiCore.Test/NJsonApiCore.Test.xproj
@@ -4,7 +4,7 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>5a06e121-32a9-4f55-8055-ab27b266eee1</ProjectGuid>
     <RootNamespace>NJsonApi.Test</RootNamespace>
@@ -16,5 +16,5 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/NJsonApiCore.Test/Serialization/ActionFilterTests.cs
+++ b/test/NJsonApiCore.Test/Serialization/ActionFilterTests.cs
@@ -319,7 +319,7 @@ namespace NJsonApi.Test.Serialization
             var context = new FilterContextBuilder()
                 .WithController<PostsController>()
                 .WithResult(new ObjectResult(post))
-                .WithQuery("include", "authors")
+                .WithQuery("include", "author")
                 .BuildActionExecuted();
 
             // Act
@@ -338,14 +338,14 @@ namespace NJsonApi.Test.Serialization
             // Arrange
             var post = new PostBuilder()
                 .WithAuthor(PostBuilder.Asimov)
-                .WithComment(1, "First")
+                .WithComment(1, "First", PostBuilder.Asimov)
                 .Build();
 
             var actionFilter = GetActionFilterForTestModel();
             var context = new FilterContextBuilder()
                 .WithController<PostsController>()
                 .WithResult(new ObjectResult(post))
-                .WithQuery("include", "authors,comments")
+                .WithQuery("include", "author,replies")
                 .BuildActionExecuted();
 
             // Act

--- a/test/NJsonApiCore.Test/Serialization/IncludedResourcesTests.cs
+++ b/test/NJsonApiCore.Test/Serialization/IncludedResourcesTests.cs
@@ -20,8 +20,8 @@ namespace NJsonApi.Test.Serialization
             // Arrange
             var source = new PostBuilder()
                 .WithAuthor(PostBuilder.Asimov)
-                .WithComment(1, "Comment One")
-                .WithComment(2, "Comment Two")
+                .WithComment(1, "Comment One", PostBuilder.Asimov)
+                .WithComment(2, "Comment Two", PostBuilder.Clarke)
                 .Build();
 
             var sourceList = new List<object>()
@@ -34,7 +34,7 @@ namespace NJsonApi.Test.Serialization
             var mapping = config.GetMapping(typeof(Post));
             var context = new Context(
                 new Uri("http://dummy:4242/posts"),
-                new string[] { "authors.comments" });
+                new string[] { "replies.author" });
 
             var transformationHelper = new TransformationHelper(config, new FakeLinkBuilder());
 
@@ -45,6 +45,7 @@ namespace NJsonApi.Test.Serialization
             Assert.NotNull(result.Single(x => x.Id == "1" && x.Type == "comments"));
             Assert.NotNull(result.Single(x => x.Id == "2" && x.Type == "comments"));
             Assert.NotNull(result.Single(x => x.Id == "1" && x.Type == "authors"));
+            Assert.NotNull(result.Single(x => x.Id == "2" && x.Type == "authors"));
             Assert.False(result.Any(x => x.Type == "posts"));
         }
 
@@ -52,20 +53,23 @@ namespace NJsonApi.Test.Serialization
         public void AppendIncludedRepresentationRecursive_RecursesWholeTree_No_Duplicates()
         {
             // Arrange
-            var duplicateAuthor = PostBuilder.Asimov;
-
             var firstSource = new PostBuilder()
-                .WithAuthor(duplicateAuthor)
+                .WithAuthor(PostBuilder.Asimov)
                 .Build();
 
             var secondSource = new PostBuilder()
-                .WithAuthor(duplicateAuthor)
+                .WithAuthor(PostBuilder.Asimov)
+                .Build();
+
+            var thirdSource = new PostBuilder()
+                .WithAuthor(PostBuilder.Clarke)
                 .Build();
 
             var sourceList = new List<object>()
             {
                 firstSource,
-                secondSource
+                secondSource,
+                thirdSource
             };
 
             var config = TestModelConfigurationBuilder.BuilderForEverything.Build();
@@ -73,7 +77,7 @@ namespace NJsonApi.Test.Serialization
             var mapping = config.GetMapping(typeof(Post));
             var context = new Context(
                 new Uri("http://dummy:4242/posts"),
-                new string[] { "authors.comments" });
+                new string[] { "author.replies" });
 
             var transformationHelper = new TransformationHelper(config, new FakeLinkBuilder());
 

--- a/test/NJsonApiCore.Test/Serialization/JsonApiTransformerTest/TestCollection.cs
+++ b/test/NJsonApiCore.Test/Serialization/JsonApiTransformerTest/TestCollection.cs
@@ -99,6 +99,7 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
             assertSame(transformedObject[1], objectsToTransform.Last());
         }
 
+
         [Fact]
         public void Creates_CompondDocument_for_collection_not_nested_class_and_propertly_map_type()
         {
@@ -158,6 +159,33 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
             };
         }
 
+        private static IEnumerable<SampleClass> CreateDerivedObjectList()
+        {
+            var objectToTransformOne = new DerivedClass
+            {
+                Id = 1,
+                SomeValue = "Somevalue text test string",
+                DateTime = DateTime.UtcNow,
+                NotMappedValue = "Should be not mapped",
+                DerivedProperty = "A value from the derived class"
+            };
+
+            var objectToTransformTwo = new DerivedClass
+            {
+                Id = 2,
+                SomeValue = "Somevalue text test string",
+                DateTime = DateTime.UtcNow.AddDays(1),
+                NotMappedValue = "Should be not mapped",
+                DerivedProperty = "A value from the derived class"
+            };
+
+            return new List<SampleClass>()
+            {
+                objectToTransformOne,
+                objectToTransformTwo
+            };
+        }
+
         private Context CreateContext()
         {
             var requestUri = new Uri("http://fakeUri:1234/fakecontroller");
@@ -171,8 +199,16 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
             mapping.ResourceType = "sampleClasses";
             mapping.AddPropertyGetter("someValue", c => c.SomeValue);
             mapping.AddPropertyGetter("date", c => c.DateTime);
+
+            var derivedMapping = new ResourceMapping<DerivedClass, DummyController>(c => c.Id);
+            derivedMapping.ResourceType = "derivedClasses";
+            derivedMapping.AddPropertyGetter("someValue", c => c.SomeValue);
+            derivedMapping.AddPropertyGetter("date", c => c.DateTime);
+            derivedMapping.AddPropertyGetter("derivedProperty", c => c.DerivedProperty);
+
             var config = new NJsonApi.Configuration();
             config.AddMapping(mapping);
+            config.AddMapping(derivedMapping);
             return config;
         }
 
@@ -182,6 +218,11 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
             public string SomeValue { get; set; }
             public DateTime DateTime { get; set; }
             public string NotMappedValue { get; set; }
+        }
+
+        private class DerivedClass : SampleClass
+        {
+            public string DerivedProperty { get; set; }
         }
     }
 }

--- a/test/NJsonApiCore.Test/Serialization/JsonApiTransformerTest/TestSingleClass.cs
+++ b/test/NJsonApiCore.Test/Serialization/JsonApiTransformerTest/TestSingleClass.cs
@@ -87,6 +87,24 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
             Assert.Equal(transformedObject.Type, "sampleClasses");
         }
 
+        [Fact]
+        public void Creates_CompondDocument_for_single_derived_class_and_propertly_map_type()
+        {
+            // Arrange
+            var context = CreateContext();
+            SampleClass objectToTransform = CreateDerivedObjectToTransform();
+            var transformer = new JsonApiTransformerBuilder()
+                .With(CreateConfiguration())
+                .Build();
+
+            // Act
+            CompoundDocument result = transformer.Transform(objectToTransform, context);
+
+            // Assert
+            var transformedObject = result.Data as SingleResource;
+            Assert.Equal(transformedObject.Type, "derivedClasses");
+        }
+
         private static SampleClass CreateObjectToTransform()
         {
             return new SampleClass
@@ -95,6 +113,18 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
                 SomeValue = "Somevalue text test string",
                 DateTime = DateTime.UtcNow,
                 NotMappedValue = "Should be not mapped"
+            };
+        }
+
+        private static DerivedClass CreateDerivedObjectToTransform()
+        {
+            return new DerivedClass
+            {
+                Id = 1,
+                SomeValue = "Somevalue text test string",
+                DateTime = DateTime.UtcNow,
+                NotMappedValue = "Should be not mapped",
+                DerivedProperty = "Derived value"
             };
         }
 
@@ -110,8 +140,15 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
             mapping.AddPropertyGetter("someValue", c => c.SomeValue);
             mapping.AddPropertyGetter("date", c => c.DateTime);
 
+            var derivedMapping = new ResourceMapping<DerivedClass, DummyController>(c => c.Id);
+            derivedMapping.ResourceType = "derivedClasses";
+            derivedMapping.AddPropertyGetter("someValue", c => c.SomeValue);
+            derivedMapping.AddPropertyGetter("date", c => c.DateTime);
+            derivedMapping.AddPropertyGetter("derivedProperty", c => c.DerivedProperty);
+
             var config = new NJsonApi.Configuration();
             config.AddMapping(mapping);
+            config.AddMapping(derivedMapping);
             return config;
         }
 
@@ -121,6 +158,11 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
             public string SomeValue { get; set; }
             public DateTime DateTime { get; set; }
             public string NotMappedValue { get; set; }
+        }
+
+        private class DerivedClass : SampleClass
+        {
+            public string DerivedProperty { get; set; }
         }
     }
 }

--- a/test/NJsonApiCore.Test/TestModel/Comment.cs
+++ b/test/NJsonApiCore.Test/TestModel/Comment.cs
@@ -5,5 +5,7 @@
         public int Id { get; set; }
         public string Body { get; set; }
         public Post Post { get; set; }
+
+        public Author Author { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #20 so that includes now use the relationship name instead of the type name. This also includes a fix for duplicate resources being included if you have multiple instances of the same object in an object graph (#24).
