### PR TITLE
Fixed updating relationships, when no attributes are specified. 

### DIFF
--- a/src/NJsonApiCore.Web.MVCCore.HelloWorld/Models/Person.cs
+++ b/src/NJsonApiCore.Web.MVCCore.HelloWorld/Models/Person.cs
@@ -2,6 +2,10 @@
 {
     public class Person
     {
+        public Person()
+        {
+        }
+
         public Person(string firstname, string lastname, string twitter)
         {
             Id = StaticPersistentStore.GetNextId();

--- a/src/NJsonApiCore/ResourceMapping.cs
+++ b/src/NJsonApiCore/ResourceMapping.cs
@@ -78,7 +78,13 @@ namespace NJsonApi
         // TODO ROLA - type handling must be better in here
         public Dictionary<string, object> GetValuesFromAttributes(Dictionary<string, object> attributes)
         {
+            
             var values = new Dictionary<string, object>();
+
+            if (attributes == null)
+            {
+                return values;
+            }
 
             foreach (var propertySetter in PropertySettersExpressions)
             {


### PR DESCRIPTION
A patch request modifying the relationship threw an error, because the attributes could not be initialized. An additional null check can solve this problem.