### PR TITLE
Fixed serialization bug

### DIFF
--- a/src/NJsonApiCore/ResourceMapping.cs
+++ b/src/NJsonApiCore/ResourceMapping.cs
@@ -60,7 +60,7 @@ namespace NJsonApi
                 var parts = relationshipPath.Split('.');
                 foreach (var part in parts)
                 {
-                    var relationship = currentMapping.Relationships.SingleOrDefault(x => x.RelatedBaseResourceType == part);
+                    var relationship = currentMapping.Relationships.FirstOrDefault(x => x.RelatedBaseResourceType == part);
                     if (relationship == null)
                         return false;
 


### PR DESCRIPTION
Fixed an issue where serialization fails if a model contains multiple linked entities of the same type. Take the following simple example: 

```c#
public class PersonModel
{
    public int Id { get; set; }
    public String FirstName { get; set; }
    public String LastName { get; set; }
}

public class MusicLessonModel
{
    public DateTime Date { get; set; }
    public int TeacherPersonId  { get; set; }
    public PersonModel TeacherPerson { get; set; }
    public int StudentPersonId  { get; set; }
    public PersonModel StudentPerson { get; set; }
}
```

Assuming the appropriate controllers have been setup, calling `http://hostname/music-lessons?include=person` results in a 500 response prior to the code change in this pr.

