### PR TITLE
Null handling

### DIFF
--- a/src/NJsonApiCore/IResourceMapping.cs
+++ b/src/NJsonApiCore/IResourceMapping.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using Newtonsoft.Json;
 
 namespace NJsonApi
 {
@@ -18,7 +19,7 @@ namespace NJsonApi
 
         bool ValidateIncludedRelationshipPaths(string[] includedPaths);
 
-        Dictionary<string, object> GetAttributes(object objectGraph);
+        Dictionary<string, object> GetAttributes(object objectGraph, JsonSerializerSettings settings);
 
         Dictionary<string, object> GetValuesFromAttributes(Dictionary<string, object> attributes);
     }

--- a/src/NJsonApiCore/ResourceMapping.cs
+++ b/src/NJsonApiCore/ResourceMapping.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using Newtonsoft.Json;
 
 namespace NJsonApi
 {
@@ -70,9 +71,18 @@ namespace NJsonApi
             return true;
         }
 
-        public Dictionary<string, object> GetAttributes(object objectGraph)
+        public Dictionary<string, object> GetAttributes(object objectGraph, JsonSerializerSettings settings)
         {
-            return PropertyGetters.ToDictionary(kvp => CamelCaseUtil.ToCamelCase(kvp.Key), kvp => kvp.Value(objectGraph));
+            if (settings.NullValueHandling == NullValueHandling.Ignore)
+            {
+                return PropertyGetters
+                    .Where(x => x.Value(objectGraph) != null)
+                    .ToDictionary(kvp => CamelCaseUtil.ToCamelCase(kvp.Key), kvp => kvp.Value(objectGraph));
+            }
+            else
+            {
+                return PropertyGetters.ToDictionary(kvp => CamelCaseUtil.ToCamelCase(kvp.Key), kvp => kvp.Value(objectGraph));
+            }
         }
 
         // TODO ROLA - type handling must be better in here

--- a/src/NJsonApiCore/Serialization/TransformationHelper.cs
+++ b/src/NJsonApiCore/Serialization/TransformationHelper.cs
@@ -8,6 +8,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Newtonsoft.Json;
 
 namespace NJsonApi.Serialization
 {
@@ -164,6 +165,17 @@ namespace NJsonApi.Serialization
             result.Id = resourceMapping.IdGetter(objectGraph).ToString();
             result.Type = resourceMapping.ResourceType;
             result.Attributes = resourceMapping.GetAttributes(objectGraph);
+
+            // Use the JSON serializer settings to determine how to handle null properties
+            if (configuration.GetJsonSerializerSettings().NullValueHandling == NullValueHandling.Ignore)
+            {
+                var keys = result.Attributes.Where(x => x.Value == null).Select(x => x.Key).ToList();
+                foreach(var key in keys)
+                {
+                    result.Attributes.Remove(key);
+                }
+            }
+            
             result.Links = new Dictionary<string, ILink>() { { "self", linkBuilder.FindResourceSelfLink(context, result.Id, resourceMapping) } };
 
             if (resourceMapping.Relationships.Any())

--- a/src/NJsonApiCore/Serialization/TransformationHelper.cs
+++ b/src/NJsonApiCore/Serialization/TransformationHelper.cs
@@ -183,18 +183,7 @@ namespace NJsonApi.Serialization
 
             result.Id = resourceMapping.IdGetter(objectGraph).ToString();
             result.Type = resourceMapping.ResourceType;
-            result.Attributes = resourceMapping.GetAttributes(objectGraph);
-
-            // Use the JSON serializer settings to determine how to handle null properties
-            if (configuration.GetJsonSerializerSettings().NullValueHandling == NullValueHandling.Ignore)
-            {
-                var keys = result.Attributes.Where(x => x.Value == null).Select(x => x.Key).ToList();
-                foreach(var key in keys)
-                {
-                    result.Attributes.Remove(key);
-                }
-            }
-            
+            result.Attributes = resourceMapping.GetAttributes(objectGraph, configuration.GetJsonSerializerSettings());            
             result.Links = new Dictionary<string, ILink>() { { "self", linkBuilder.FindResourceSelfLink(context, result.Id, resourceMapping) } };
 
             if (resourceMapping.Relationships.Any())

--- a/test/NJsonApiCore.Test/Serialization/JsonApiTransformerTest/TestSingleClass.cs
+++ b/test/NJsonApiCore.Test/Serialization/JsonApiTransformerTest/TestSingleClass.cs
@@ -5,6 +5,7 @@ using NJsonApi.Test.TestControllers;
 using System;
 using System.Collections.Generic;
 using Xunit;
+using Newtonsoft.Json;
 
 namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
 {
@@ -88,6 +89,48 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
         }
 
         [Fact]
+        public void Creates_CompoundDocument_for_single_not_nested_class_and_properly_suppress_nullable_properties()
+        {
+            // Arrange
+            var context = CreateContext();
+            SampleClassWithNullableProperty objectToTransform = CreateObjectWithNullPropertyToTransform();
+            var config = CreateConfiguration();
+            config.GetJsonSerializerSettings().NullValueHandling = NullValueHandling.Ignore;
+            var transformer = new JsonApiTransformerBuilder()
+                .With(config)
+                .Build();
+
+            // Act
+            CompoundDocument result = transformer.Transform(objectToTransform, context);
+
+            // Assert
+            var transformedObject = result.Data as SingleResource;
+            Assert.Equal(transformedObject.Attributes["someValue"], objectToTransform.SomeValue);
+            Assert.False(transformedObject.Attributes.ContainsKey("date"));
+            Assert.Equal(transformedObject.Attributes.Count, 1);
+        }
+
+        [Fact]
+        public void Creates_CompoundDocument_for_single_not_nested_class_and_properly_do_not_suppress_nullable_properties()
+        {
+            // Arrange
+            var context = CreateContext();
+            SampleClassWithNullableProperty objectToTransform = CreateObjectWithNullPropertyToTransform();
+            var transformer = new JsonApiTransformerBuilder()
+                .With(CreateConfiguration())
+                .Build();
+
+            // Act
+            CompoundDocument result = transformer.Transform(objectToTransform, context);
+
+            // Assert
+            var transformedObject = result.Data as SingleResource;
+            Assert.Equal(transformedObject.Attributes["someValue"], objectToTransform.SomeValue);
+            Assert.Equal(transformedObject.Attributes["date"], null);
+            Assert.Equal(transformedObject.Attributes.Count, 2);
+        }
+
+        [Fact]
         public void Creates_CompondDocument_for_single_derived_class_and_propertly_map_type()
         {
             // Arrange
@@ -112,6 +155,16 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
                 Id = 1,
                 SomeValue = "Somevalue text test string",
                 DateTime = DateTime.UtcNow,
+                NotMappedValue = "Should be not mapped"
+            };
+        }
+        private static SampleClassWithNullableProperty CreateObjectWithNullPropertyToTransform()
+        {
+            return new SampleClassWithNullableProperty()
+            {
+                Id = 1,
+                SomeValue = "Somevalue text test string",
+                DateTime = null,
                 NotMappedValue = "Should be not mapped"
             };
         }
@@ -140,6 +193,11 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
             mapping.AddPropertyGetter("someValue", c => c.SomeValue);
             mapping.AddPropertyGetter("date", c => c.DateTime);
 
+            var nullableMapping = new ResourceMapping<SampleClassWithNullableProperty, DummyController>(c => c.Id);
+            nullableMapping.ResourceType = "sampleClassesWithNullableProperty";
+            nullableMapping.AddPropertyGetter("someValue", c => c.SomeValue);
+            nullableMapping.AddPropertyGetter("date", c => c.DateTime);
+
             var derivedMapping = new ResourceMapping<DerivedClass, DummyController>(c => c.Id);
             derivedMapping.ResourceType = "derivedClasses";
             derivedMapping.AddPropertyGetter("someValue", c => c.SomeValue);
@@ -148,6 +206,7 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
 
             var config = new NJsonApi.Configuration();
             config.AddMapping(mapping);
+            config.AddMapping(nullableMapping);
             config.AddMapping(derivedMapping);
             return config;
         }
@@ -157,6 +216,13 @@ namespace NJsonApi.Test.Serialization.JsonApiTransformerTest
             public int Id { get; set; }
             public string SomeValue { get; set; }
             public DateTime DateTime { get; set; }
+            public string NotMappedValue { get; set; }
+        }
+        private class SampleClassWithNullableProperty
+        {
+            public int Id { get; set; }
+            public string SomeValue { get; set; }
+            public DateTime? DateTime { get; set; }
             public string NotMappedValue { get; set; }
         }
 


### PR DESCRIPTION
Addresses **Streaming of nullable types should not serialize as empty string when no value (https://github.com/brainwipe/NJsonApiCore/issues/42).**  This PR uses the NullValueHandling property of SerializerSettings to control whether attributes with null values are suppressed.

JSON.Net also supports NullValueHandling to be applied on a per property basis using attributes - this functionality has not been included here.