### PR TITLE
Fixes ApplySimpleProperties for simple types.

### DIFF
--- a/src/NJsonApiCore/Infrastructure/Delta.cs
+++ b/src/NJsonApiCore/Infrastructure/Delta.cs
@@ -73,8 +73,20 @@ namespace NJsonApi.Infrastructure
                 Action<T, object> setter;
 
                 currentTypeSetters.TryGetValue(ToProperCase(objectPropertyNameValue.Key), out setter);
+
+                PropertyInfo propertyInfo = typeof(T)
+                    .GetProperties()
+                    .SingleOrDefault(p => !(typeof(ICollection).IsAssignableFrom(p.PropertyType)) && p.Name == ToProperCase(objectPropertyNameValue.Key));
+
                 if (setter != null)
-                    setter(inputObject, objectPropertyNameValue.Value);
+                {
+                    object value = objectPropertyNameValue.Value;
+                    if (value != null)
+                        if (propertyInfo != null && (value.GetType() != propertyInfo.PropertyType))
+                            value = Convert.ChangeType(value, Nullable.GetUnderlyingType(propertyInfo.PropertyType) ?? propertyInfo.PropertyType);
+
+                    setter(inputObject, value);
+                }
             }
         }
 

--- a/test/NJsonApiCore.Test/Infrastructure/DeltaTest.cs
+++ b/test/NJsonApiCore.Test/Infrastructure/DeltaTest.cs
@@ -46,5 +46,30 @@ namespace NJsonApi.Test.Infrastructure
             Assert.Null(simpleObject.Name);
             Assert.Equal(simpleObject.DateTimeCreated, new DateTime());
         }
+
+        [Fact]
+        public void GIVEN_SimplePropertiesOfDifferentTypes_WHEN_ApplySimpleProperties_THEN_PropertiesAreApplied()
+        {
+            //Arrange
+            var simpleObject = new SimpleTypes();
+            var objectUnderTest = new Delta<SimpleTypes>();
+
+            //Act
+            objectUnderTest.ObjectPropertyValues =
+                new Dictionary<string, object>()
+                {
+                    {"TestInt", 154},
+                    {"NullableInt", "54"},
+                    {"TestDouble", 100},
+                    {"NullableDouble", 115.5f}
+                };
+            objectUnderTest.ApplySimpleProperties(simpleObject);
+
+            //Assert
+            Assert.Equal(simpleObject.TestInt, 154);
+            Assert.Equal(simpleObject.NullableInt, 54);
+            Assert.Equal(simpleObject.TestDouble, 100d);
+            Assert.Equal(simpleObject.NullableDouble, 115.5d);
+        }
     }
 }

--- a/test/NJsonApiCore.Test/TestModel/SimpleTypes.cs
+++ b/test/NJsonApiCore.Test/TestModel/SimpleTypes.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NJsonApi.Test.TestModel
+{
+    public class SimpleTypes
+    {
+        public int TestInt { get; set; }
+        public int? NullableInt { get; set; }
+
+        public double TestDouble { get; set; }
+        public double? NullableDouble { get; set; }
+    }
+}


### PR DESCRIPTION
This should fix #32. By using the default system convert methods we should be able to handle the disconnect between the JSON types and the model types.